### PR TITLE
Atualiza README para apresentação de portfólio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,212 @@
-# KM One Monorepo
+# KM One
 
-- web/ (landing)
-- backend/ (API)
-- mobile/ (app)
+Copiloto financeiro para motoristas de aplicativo acompanharem corridas, custos, metas e qualidade das ofertas em uma rotina de trabalho mais inteligente.
 
-Pendente pro MVP (pick & play)
+## Visão geral
 
-Fluxo de edição/exclusão
+KM One é uma plataforma voltada para motoristas de aplicativo que precisam tomar decisões rápidas durante o dia e, ao mesmo tempo, manter clareza sobre receita, quilometragem, abastecimentos e desempenho operacional.
 
-✅ Editar ride (ok)
+O projeto reúne um aplicativo mobile, uma landing page pública e uma API backend. A experiência principal está no app, onde o motorista registra corridas, acompanha métricas do dia, controla abastecimentos, consulta histórico e utiliza critérios personalizados para avaliar oportunidades de corrida.
 
-☐ Excluir via toast/undo também na Home (mesma UX do Histórico)
+## Problema
 
-☐ Editar/excluir abastecimento
+Motoristas de aplicativo lidam com muitas variáveis ao mesmo tempo: valor da corrida, distância, tempo estimado, meta diária, combustível, deslocamentos sem passageiro e desempenho por quilômetro. Quando essas informações ficam espalhadas ou são calculadas manualmente, a tomada de decisão fica mais lenta e menos consistente.
 
-Metas e alertas
+O KM One nasce para organizar esse fluxo e transformar dados operacionais do dia a dia em sinais simples para decisão.
 
-☐ Meta diária com streak simples (dias batidos seguidos)
+## Solução
 
-☐ Alerta de “faltam R$ X pra meta” com CTA pra registrar corrida/abastecimento
+A solução centraliza os principais controles financeiros e operacionais do motorista em um app mobile. O usuário pode registrar corridas e abastecimentos, acompanhar metas, calcular indicadores como receita por quilômetro e consultar históricos por período.
 
-☐ Meta R$/km por app (Uber/99) opcional
+O projeto também inclui um radar de ofertas com parâmetros configuráveis. A partir de critérios como valor mínimo, R$/km e R$/hora, o app classifica oportunidades e ajuda o motorista a decidir com mais clareza.
 
-GPS & tracking
+## Funcionalidades
 
-☐ Pausar/retomar corrida (além de iniciar/encerrar)
+- Registro manual de corridas com valor recebido, quilometragem, aplicativo e duração.
+- Edição e exclusão de corridas.
+- Acompanhamento de métricas do dia, incluindo bruto, quilômetros, R$/km, quantidade de corridas e tempo acumulado.
+- Meta diária de faturamento com progresso visual.
+- Registro de abastecimentos com valor, litros e tipo de combustível.
+- Edição, exclusão e desfazer exclusão de abastecimentos.
+- Histórico por data com totais de receita, quilometragem, combustível e líquido estimado.
+- Exportação de corridas em CSV por dia, semana e mês.
+- Tracking de deslocamentos com GPS para registrar corridas particulares ou períodos livres.
+- Entrada por voz para valores de corrida no fluxo manual.
+- Radar manual de ofertas com avaliação por valor, distância e tempo.
+- Radar Android com overlay, permissões dedicadas e leitura de ofertas via recursos nativos.
+- Configuração de meta diária, R$/km mínimo e critérios mínimos para avaliação de ofertas.
+- Landing page pública com apresentação do produto e formulário de interesse.
+- API HTTP para configuração, cadastro e listagem de corridas.
 
-☐ Proteção contra pocket touches (confirmação ao encerrar)
+## Stack
 
-☐ Aviso de GPS desligado/sem permissão + atalho
+### Mobile
 
-Histórico
+- React Native
+- Expo
+- TypeScript
+- NativeWind / Tailwind CSS
+- Zustand
+- AsyncStorage
+- Expo Location
+- Expo FileSystem e Sharing
+- Expo Speech Recognition
+- Código nativo Android em Kotlin para overlay, acessibilidade, captura de tela e OCR
 
-☐ Filtro por app e por faixa de valor
+### Web
 
-☐ Totais por dia/semana/mês (apenas UI; nada de export por enquanto)
+- React
+- TypeScript
+- Vite
+- Tailwind CSS
+- React Hook Form
+- Zod
+- Lucide React
+- Formspree
 
-☐ Busca por observação (se formos adicionar obs nas corridas)
+### Backend
 
-Abastecimento
+- Node.js
+- Express
+- TypeScript
+- PostgreSQL
+- Neon Serverless/Postgres client
+- Serverless Framework
+- AWS Lambda / HTTP API
+- Docker Compose para banco local
 
-☐ Calcular custo/km do dia (combustível/quilômetro)
+## Arquitetura
 
-☐ Tipo de combustível padrão (memória)
+O repositório está organizado como um monorepo com três frentes principais:
 
-☐ Botão “repetir último posto” (auto-preenche)
+```text
+backend/   API HTTP, acesso a dados e deploy serverless
+mobile-v2/ Aplicativo mobile principal em React Native/Expo
+mobile/    Versão mobile inicial mantida no repositório
+web/       Landing page pública em React/Vite
+```
 
-UX / UI polimento
+No mobile, a aplicação separa telas, componentes reutilizáveis, estado e regras de domínio. Os dados locais de corridas, abastecimentos, configurações e tracking são persistidos com AsyncStorage por meio de stores e repositórios internos.
 
-☐ Estados vazios mais “vivos” (ilustra + CTA)
+A camada Android nativa complementa o app Expo com serviços específicos para o radar de ofertas: Accessibility Service, overlay flutuante, captura de tela, processamento de frames e integração com a ponte JavaScript/React Native.
 
-☐ Haptics em mais ações (salvar/excluir/erro)
+O backend expõe rotas REST para health check, configuração e corridas, com persistência em PostgreSQL. A API pode rodar localmente via Express e também ser empacotada para execução serverless.
 
-☐ Pequenas animações (fade/scale) nas listas
+A landing page apresenta a proposta de valor do produto, principais benefícios e formulário de captação de interesse.
 
-Resiliência & dados
+## Como rodar
 
-☐ Validações de input (número, mínimo/máximo, vírgula/ponto)
+### Pré-requisitos
 
-☐ Sanitização de chaves no AsyncStorage (evitar sujar storage)
+- Node.js 20+
+- npm
+- Docker e Docker Compose para o banco local do backend
+- Expo CLI/EAS quando for executar builds mobile nativos
+- Ambiente Android configurado para `expo run:android`, quando necessário
 
-☐ Migração leve caso mudemos o formato (v1 → v2)
+### Backend
 
-Configurações
+```bash
+cd backend
+npm install
+cat > .env.local <<'ENV'
+DATABASE_URL="postgres://dev:dev@localhost:5432/kmone"
+NODE_ENV="development"
+ENV
+npm run dev:db
+npm run dev
+```
 
-☐ Reset rápido do dia (apagar tudo do dia atual com confirmação)
+Com a API em execução, os endpoints principais ficam disponíveis no servidor local do Express.
 
-☐ Importar dados locais de backup (.json simples)
+### Mobile principal
 
-☐ Mostrar versão do app + build info
+```bash
+cd mobile-v2
+npm install
+npm start
+```
 
-Erros & logs
+Para executar com código nativo Android:
 
-☐ Tratamento visual de erros (banner discreto)
+```bash
+cd mobile-v2
+npm run android
+```
 
-☐ Log de diagnóstico opcional (toggle em Config)
+### Landing page
 
-Acessibilidade & idioma
+```bash
+cd web
+npm install
+npm run dev
+```
 
-☐ Dinâmico para font size do sistema
+### Mobile inicial
 
-☐ VoiceOver/TalkBack labels básicos
+```bash
+cd mobile
+npm install
+npm start
+```
 
-☐ Ajuste de contraste nos chips/botões
+## Configuração
 
-Qualidade
+Crie arquivos de ambiente locais conforme a necessidade de cada módulo e mantenha valores sensíveis fora do versionamento.
 
-☐ Testes unitários dos use cases (rides/settings/fuel)
+### Backend
 
-☐ Teste de cálculo de R$/km e metas
+```env
+DATABASE_URL="postgres://usuario:senha@host:porta/banco"
+NODE_ENV="development"
+```
 
-☐ Smoke test: iniciar → encerrar → editar → excluir
+`DATABASE_URL` é obrigatória para conexão com PostgreSQL. Em ambientes de staging ou produção, a aplicação também usa essa variável para configurar conexão SSL quando apropriado.
 
-Build & entrega
+### Web
 
-☐ EAS build config mínima (dev/prod)
+A landing page utiliza integração com Formspree para envio de formulário. Caso o identificador do formulário seja parametrizado no futuro, mantenha-o em variável de ambiente pública do Vite, por exemplo:
 
-☐ Ícones/splash final
+```env
+VITE_FORMSPREE_FORM_ID="seu_form_id"
+```
 
-☐ Versionamento semântico e CHANGELOG
+### Mobile
 
-Segurança/privacidade
+O app mobile principal utiliza persistência local e permissões do dispositivo. Para recursos nativos do radar Android, as permissões de overlay, acessibilidade e captura de tela são solicitadas no próprio fluxo do aplicativo.
 
-☐ Aviso simples de privacidade (dados locais no dispositivo)
+## Decisões técnicas
 
-☐ Botão “apagar tudo” (wipe)
+- **Monorepo por produto**: backend, mobile e web convivem no mesmo repositório para facilitar evolução coordenada da plataforma.
+- **Mobile-first**: a experiência principal fica no app, alinhada ao contexto de uso do motorista durante a jornada de trabalho.
+- **Persistência local no app**: corridas, abastecimentos e configurações são armazenados no dispositivo para uma experiência rápida e independente de conexão constante.
+- **Critérios configuráveis**: metas e parâmetros do radar ficam sob controle do usuário, permitindo que a avaliação de ofertas reflita sua estratégia de trabalho.
+- **Separação de domínio e interface**: stores, utilitários e casos de uso ajudam a manter regras de cálculo fora dos componentes visuais.
+- **Backend serverless**: a API foi estruturada para rodar localmente durante o desenvolvimento e em ambiente serverless para entrega na nuvem.
+- **Camada nativa Android dedicada**: recursos como overlay, acessibilidade e captura de tela foram implementados nativamente para viabilizar uma experiência integrada ao fluxo real de decisão do motorista.
+
+## Status
+
+O projeto está em desenvolvimento ativo, com foco no aplicativo mobile principal, na experiência de decisão para motoristas e na base de dados operacional. A versão atual já reúne os fluxos centrais de registro, acompanhamento de métricas, histórico, abastecimentos, configurações e landing page pública.
+
+## Roadmap
+
+- Evoluir indicadores comparativos por turno, região e aplicativo.
+- Aprimorar visualizações de histórico com filtros e agrupamentos adicionais.
+- Expandir recursos de metas, alertas e acompanhamento de progresso.
+- Fortalecer recursos de backup, importação e exportação de dados.
+- Ampliar acessibilidade e refinamentos de experiência no app mobile.
+- Consolidar fluxos de build, versionamento e distribuição mobile.
+- Explorar integrações e parcerias voltadas à redução de custos do motorista.
+
+## O que este projeto demonstra
+
+- Construção de produto mobile com React Native, Expo e TypeScript.
+- Modelagem de fluxos reais de usuário com foco em decisão operacional e controle financeiro.
+- Implementação de estado local, persistência offline e organização por domínio.
+- Desenvolvimento de componentes reutilizáveis e interfaces orientadas a métricas.
+- Integração com APIs nativas Android em um projeto Expo.
+- Uso de GPS, exportação de arquivos, compartilhamento e entrada por voz no mobile.
+- Criação de backend REST com TypeScript, Express, PostgreSQL e deploy serverless.
+- Desenvolvimento de landing page moderna com React, Vite e Tailwind CSS.
+- Organização de monorepo com múltiplas superfícies de produto.


### PR DESCRIPTION
### Motivation

- Tornar o `README.md` adequado para apresentação pública a recrutadores e líderes técnicos, com tom profissional e confiante.
- Remover linguagem de diagnóstico, listas internas de pendências e comentários que possam sugerir riscos ou análises internas.
- Reorganizar o conteúdo para destacar problema, solução, funcionalidades, stack, arquitetura, instruções de execução e decisões técnicas.
- Manter a alteração limitada ao arquivo `README.md` sem tocar no código-fonte ou em arquivos de configuração.

### Description

- Substituí a checklist interna e anotações operacionais por seções orientadas a produto: Visão geral, Problema, Solução, Funcionalidades, Stack, Arquitetura, Como rodar, Configuração, Decisões técnicas, Status, Roadmap e O que este projeto demonstra.
- Listei apenas funcionalidades reais encontradas no repositório e documentei a stack por módulo (Mobile, Web, Backend) e a organização do monorepo.
- Adicionei instruções concisas para executar localmente (backend, mobile-v2, web e mobile) e um exemplo de arquivo de ambiente local ilustrativo sem expor credenciais reais.
- A alteração afetou apenas o `README.md` e removeu conteúdo de tom analítico/operacional, mantendo foco em apresentação profissional do projeto.

### Testing

- Rodei `rg -n "recomenda|risco|ponto fraco|a confirmar|aparentemente|parece|foi identificado|deveria|diagn[oó]stico|pendente|problema|melhorar" README.md` para garantir que a linguagem proibida não aparece; não foram encontrados resultados.
- Executei `git diff --check` para checar problemas simples de formatação e não foram retornados erros.
- Verifiquei o estado do repositório com `git status --short` e confirmei o último commit com `git log -1 --oneline` para assegurar que a mudança está limitada ao `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee09ed78483258ecac940adb06ddf)